### PR TITLE
CET-510/fix: Fix magento calculations

### DIFF
--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [tool.bumpver]
-current_version = "1.6.8"
+current_version = "1.7.0"
 version_pattern = "MAJOR.MINOR.PATCH[-TAGNUM]"
 commit_message = "chore: Bump version {old_version} -> {new_version}"
 commit = true

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "two-inc/magento2",
     "description": "Two B2B BNPL payments extension",
     "type": "magento2-module",
-    "version": "1.6.8",
+    "version": "1.7.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,7 +11,7 @@
         <payment>
             <two_payment>
                 <active>1</active>
-                <version>1.6.8</version>
+                <version>1.7.0</version>
                 <title>Business invoice - 30 days</title>
                 <mode>sandbox</mode>
                 <invoice_type>FUNDED_INVOICE</invoice_type>


### PR DESCRIPTION
At present, we derive the gross amount for line item. This is causing rounding error in some cases.
Instead we should use gross amount provided by magento
