### PR TITLE
CET-533/fix: Magento: Remove merchant_short_name input from admin settings

### DIFF
--- a/Api/Config/RepositoryInterface.php
+++ b/Api/Config/RepositoryInterface.php
@@ -22,7 +22,6 @@ interface RepositoryInterface
     public const XML_PATH_ENABLED = 'payment/two_payment/active';
     public const XML_PATH_TITLE = 'payment/two_payment/title';
     public const XML_PATH_MODE = 'payment/two_payment/mode';
-    public const XML_PATH_MERCHANT_SHORT_NAME = 'payment/two_payment/merchant_short_name';
     public const XML_PATH_API_KEY = 'payment/two_payment/api_key';
     public const XML_PATH_DAYS_ON_INVOICE = 'payment/two_payment/days_on_invoice';
     public const XML_PATH_FULFILL_TRIGGER = 'payment/two_payment/fulfill_trigger';
@@ -58,15 +57,6 @@ interface RepositoryInterface
      * @return string
      */
     public function getMode(?int $storeId = null): string;
-
-    /**
-     * Get merchant short name
-     *
-     * @param int|null $storeId
-     *
-     * @return string
-     */
-    public function getMerchantShortName(?int $storeId = null): string;
 
     /**
      * Get API key

--- a/Model/Config/Repository.php
+++ b/Model/Config/Repository.php
@@ -80,14 +80,6 @@ class Repository implements RepositoryInterface
     }
 
     /**
-     * @inheritDoc
-     */
-    public function getMerchantShortName(?int $storeId = null): string
-    {
-        return (string)$this->getConfig(self::XML_PATH_MERCHANT_SHORT_NAME, $storeId);
-    }
-
-    /**
      * Retrieve config value
      *
      * @param string $configPath

--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [tool.bumpver]
-current_version = "1.7.2"
+current_version = "1.7.3"
 version_pattern = "MAJOR.MINOR.PATCH[-TAGNUM]"
 commit_message = "chore: Bump version {old_version} -> {new_version}"
 commit = true

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "two-inc/magento2",
     "description": "Two B2B BNPL payments extension",
     "type": "magento2-module",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -40,15 +40,6 @@
                     </depends>
                     <config_path>payment/two_payment/mode</config_path>
                 </field>
-                <field id="merchant_short_name" translate="label" type="text" sortOrder="40" showInDefault="1"
-                       showInWebsite="1" showInStore="1">
-                    <label>Username</label>
-                    <comment>Username for your merchant account</comment>
-                    <depends>
-                        <field id="active">1</field>
-                    </depends>
-                    <config_path>payment/two_payment/merchant_short_name</config_path>
-                </field>
                 <field id="api_key" translate="label" type="obscure" sortOrder="50" showInDefault="1" showInWebsite="1"
                        showInStore="1">
                     <label>API key</label>
@@ -62,7 +53,6 @@
                 </field>
                 <field id="api_key_check" translate="label" type="button" sortOrder="55" showInDefault="1"
                        showInWebsite="1" showInStore="1">
-                    <label>Credentials</label>
                     <frontend_model>Two\Gateway\Block\Adminhtml\System\Config\Field\ApiKeyCheck</frontend_model>
                 </field>
                 <field id="debug" translate="label" type="select" sortOrder="60" showInDefault="1" showInWebsite="1"

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -11,7 +11,7 @@
         <payment>
             <two_payment>
                 <active>1</active>
-                <version>1.7.2</version>
+                <version>1.7.3</version>
                 <title>Business invoice - 30 days</title>
                 <mode>sandbox</mode>
                 <invoice_type>FUNDED_INVOICE</invoice_type>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -8,6 +8,9 @@
 "%1 requires whole order to be shipped before it can be fulfilled.","%1 requires whole order to be shipped before it can be fulfilled."
 "* Required Fields","* Required Fields"
 "API key","API key"
+"API key is missing","API key is missing"
+"API key is not valid","API key is not valid"
+"API key is valid","API key is valid"
 "Add PO number field","Add PO number field"
 "Add department field","Add department field"
 "Add order note field","Add order note field"
@@ -29,15 +32,10 @@ Branding,Branding
 "Could not initiate refund with %1","Could not initiate refund with %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3"
 "Country is not valid.","Country is not valid."
-Credentials,Credentials
-"Credentials are invalid","Credentials are invalid"
-"Credentials are missing","Credentials are missing"
-"Credentials are valid","Credentials are valid"
 "Credit Note","Credit Note"
 "Debug mode","Debug mode"
 Department,Department
 "Developed by Magmodules.","Developed by Magmodules."
-"Display info link","Display info link"
 Download,Download
 "Download as .txt file","Download as .txt file"
 "Email Address is not valid.","Email Address is not valid."
@@ -96,8 +94,6 @@ Title,Title
 "Two is a payment solution for B2B purchases online, allowing you to buy from your favourite merchants and suppliers on trade credit. Using Two, you can access flexible trade credit instantly to make purchasing simple.","Two is a payment solution for B2B purchases online, allowing you to buy from your favourite merchants and suppliers on trade credit. Using Two, you can access flexible trade credit instantly to make purchasing simple."
 "Unable to find the requested %1 order","Unable to find the requested %1 order"
 "Unable to retrieve payment information for your invoice purchase with %1. The cart will be restored.","Unable to retrieve payment information for your invoice purchase with %1. The cart will be restored."
-Username,Username
-"Username should be set to %1","Username should be set to %1"
 Version,Version
 "You must first accept the payment terms.","You must first accept the payment terms."
 "You will be redirected to %1 when you place order.","You will be redirected to %1 when you place order."

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -8,6 +8,9 @@
 "%1 requires whole order to be shipped before it can be fulfilled.","%1 krever at hele bestillingen sendes før den kan oppfylles."
 "* Required Fields","* Obligatoriske felter"
 "API key",API-nøkkel
+"API key is missing","API-nøkkel mangler"
+"API key is not valid","API-nøkkel er ikke gyldig"
+"API key is valid","API-nøkkel er gyldig"
 "Add PO number field","Legg til PO-nummerfelt"
 "Add department field","Legg til felt for avdeling"
 "Add order note field","Legg til bestillingsnotatfelt"
@@ -29,15 +32,10 @@ Branding,Merkevarebygging
 "Could not initiate refund with %1","Kunne ikke starte refusjon med %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kunne ikke oppdatere %1 ordrestatus til kansellert. Ta kontakt med brukerstøtten med ordre-ID %2. Feil: %3"
 "Country is not valid.","Land er ikke gyldig."
-Credentials,Legitimasjon
-"Credentials are invalid","Legitimasjonen er ugyldig"
-"Credentials are missing","Legitimasjon mangler"
-"Credentials are valid","Legitimasjonen er gyldig"
 "Credit Note",Kreditnota
 "Debug mode",Feilsøkingsmodus
 Department,Avdeling
 "Developed by Magmodules.","Utviklet av Magmodules."
-"Display info link","Vis infolink"
 Download,"Last ned"
 "Download as .txt file","Last ned som .txt-fil"
 "Email Address is not valid.","E-postadresse er ikke gyldig."
@@ -96,8 +94,6 @@ Title,Tittel
 "Two is a payment solution for B2B purchases online, allowing you to buy from your favourite merchants and suppliers on trade credit. Using Two, you can access flexible trade credit instantly to make purchasing simple.","Two er en betalingsløsning for B2B-kjøp på nettet, som lar deg kjøpe fra dine favorittforhandlere og leverandører på handelskreditt. Med Two kan du få tilgang til fleksibel handelskreditt umiddelbart for å gjøre innkjøp enkelt."
 "Unable to find the requested %1 order","Kan ikke finne den forespurte bestillingen %1"
 "Unable to retrieve payment information for your invoice purchase with %1. The cart will be restored.","Kan ikke hente betalingsinformasjon for fakturakjøpet med %1. Vognen vil bli restaurert."
-Username,Brukernavn
-"Username should be set to %1","Brukernavn skal settes til %1"
 Version,Versjon
 "You must first accept the payment terms.","Du må først godta betalingsvilkårene."
 "You will be redirected to %1 when you place order.","Du vil bli omdirigert til %1 når du legger inn bestilling."

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -8,6 +8,9 @@
 "%1 requires whole order to be shipped before it can be fulfilled.","%1 vereist dat de gehele bestelling wordt verzonden voordat deze kan worden uitgevoerd."
 "* Required Fields","* Verplichte velden"
 "API key",API-sleutel
+"API key is missing","API-sleutel ontbreekt"
+"API key is not valid","API-sleutel is niet geldig"
+"API key is valid","API-sleutel is geldig"
 "Add PO number field","PO-nummer veld toevoegen"
 "Add department field","Afdelingsveld toevoegen"
 "Add order note field","Bestelnotitie veld toevoegen"
@@ -29,15 +32,10 @@ Branding,Merknaam
 "Could not initiate refund with %1","Kon geen terugbetaling starten met %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kon %1 orderstatus niet updaten naar geannuleerd. Neem contact op met support met bestelnummer %2. Fout: %3"
 "Country is not valid.","Land is niet geldig."
-Credentials,Inloggegevens
-"Credentials are invalid","Inloggegevens zijn ongeldig"
-"Credentials are missing","Inloggegevens ontbreken"
-"Credentials are valid","Inloggegevens zijn geldig"
 "Credit Note",Creditnota
 "Debug mode",Debug-modus
 Department,Afdeling
 "Developed by Magmodules.","Ontwikkeld door Magmodules."
-"Display info link","Infolink weergeven"
 Download,Download
 "Download as .txt file","Downloaden als .txt-bestand"
 "Email Address is not valid.","E-mailadres is niet geldig."
@@ -96,8 +94,6 @@ Title,Titel
 "Two is a payment solution for B2B purchases online, allowing you to buy from your favourite merchants and suppliers on trade credit. Using Two, you can access flexible trade credit instantly to make purchasing simple.","Two is een betalingsoplossing voor online B2B-aankopen, waarmee u op handelskrediet kunt kopen bij uw favoriete handelaren en leveranciers. Met Two heeft u direct toegang tot flexibel handelskrediet om het aankopen eenvoudig te maken."
 "Unable to find the requested %1 order","Kan de gevraagde %1 bestelling niet vinden"
 "Unable to retrieve payment information for your invoice purchase with %1. The cart will be restored.","Betalingsgegevens voor uw aankoop op factuur met %1 kunnen niet worden opgehaald. De winkelwagen wordt hersteld."
-Username,Gebruikersnaam
-"Username should be set to %1","Gebruikersnaam moet ingesteld worden op %1"
 Version,Versie
 "You must first accept the payment terms.","U moet eerst de betaalvoorwaarden accepteren."
 "You will be redirected to %1 when you place order.","U wordt doorgestuurd naar %1 wanneer u een bestelling plaatst."

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -8,6 +8,9 @@
 "%1 requires whole order to be shipped before it can be fulfilled.","%1 kräver att hela beställningen skickas innan den kan uppfyllas."
 "* Required Fields","* Obligatoriska fält"
 "API key",API-nyckel
+"API key is missing","API-nyckel saknas"
+"API key is not valid","API-nyckeln är inte giltig"
+"API key is valid","API-nyckeln är giltig"
 "Add PO number field","Lägg till PO-nummerfält"
 "Add department field","Lägg till fält för avdelning"
 "Add order note field","Lägg till orderanteckningsfält"
@@ -29,15 +32,10 @@ Branding,Branding
 "Could not initiate refund with %1","Kunde inte initiera återbetalning med %1"
 "Could not update %1 order status to cancelled. Please contact support with order ID %2. Error: %3","Kunde inte uppdatera %1 orderstatus till annullerad. Kontakta supporten med beställnings-ID %2. Fel: %3"
 "Country is not valid.","Land är inte giltigt."
-Credentials,Autentiseringsuppgifter
-"Credentials are invalid","Autentiseringsuppgifterna är ogiltiga"
-"Credentials are missing","Autentiseringsuppgifterna saknas"
-"Credentials are valid","Autentiseringsuppgifterna är giltiga"
 "Credit Note",Kreditnota
 "Debug mode",Felsökningsläge
 Department,Avdelning
 "Developed by Magmodules.","Utvecklad av Magmodules."
-"Display info link","Visa infolänk"
 Download,"Ladda ner"
 "Download as .txt file","Ladda ner som .txt-fil"
 "Email Address is not valid.","E-postadress är inte giltig."
@@ -96,8 +94,6 @@ Title,Titel
 "Two is a payment solution for B2B purchases online, allowing you to buy from your favourite merchants and suppliers on trade credit. Using Two, you can access flexible trade credit instantly to make purchasing simple.","Two är en betalningslösning för B2B-köp online, som låter dig köpa från dina favorithandlare och leverantörer på handelskredit. Med Two får du omedelbar tillgång till flexibel handelskredit för att göra inköp enkelt."
 "Unable to find the requested %1 order","Det gick inte att hitta den begärda beställningen %1"
 "Unable to retrieve payment information for your invoice purchase with %1. The cart will be restored.","Det gick inte att hämta betalningsinformation för ditt fakturaköp med %1. Vagnen kommer att återställas."
-Username,Användarnamn
-"Username should be set to %1","Användarnamn ska ställas in till %1"
 Version,Version
 "You must first accept the payment terms.","Du måste först acceptera betalningsvillkoren."
 "You will be redirected to %1 when you place order.","Du kommer att omdirigeras till %1 när du beställer."

--- a/view/frontend/web/js/view/payment/method-renderer/two_payment.js
+++ b/view/frontend/web/js/view/payment/method-renderer/two_payment.js
@@ -356,7 +356,8 @@ define([
                         phone_number: this.getTelephone()
                     }
                 },
-                merchant_short_name: config.orderIntentConfig.merchantShortName
+                merchant_id: config.orderIntentConfig.merchant?.id,
+                merchant_short_name: config.orderIntentConfig.merchant?.short_name
             };
 
             console.debug({ logger: 'twoPayment.placeOrderIntent', orderIntentRequestBody });


### PR DESCRIPTION
Instead, get values from verify API key endpoint prior to passing config to frontend.
