### PR TITLE
CET-537/fix: Issue with saving address for logged in customers

### DIFF
--- a/Controller/Payment/Cancel.php
+++ b/Controller/Payment/Cancel.php
@@ -52,6 +52,7 @@ class Cancel extends Action
      */
     public function execute()
     {
+        $order = null;
         try {
             $order = $this->orderService->getOrderByReference();
             $this->orderService->cancelTwoOrder($order);
@@ -62,10 +63,9 @@ class Cancel extends Action
             throw new LocalizedException($message);
         } catch (Exception $exception) {
             $this->orderService->restoreQuote();
-            if (isset($order)) {
+            if ($order !== null) {
                 $this->orderService->failOrder($order, $exception->getMessage());
             }
-
             $this->messageManager->addErrorMessage($exception->getMessage());
             return $this->getResponse()->setRedirect($this->_url->getUrl('checkout/cart'));
         }

--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -9,7 +9,6 @@ namespace Two\Gateway\Controller\Payment;
 
 use Exception;
 use Magento\Customer\Api\AddressRepositoryInterface;
-use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\ResponseInterface;
@@ -34,11 +33,6 @@ class Confirm extends Action
     private $addressRepository;
 
     /**
-     * @var SearchCriteriaInterface
-     */
-    private $searchCriteria;
-
-    /**
      * @var OrderService
      */
     private $orderService;
@@ -51,13 +45,11 @@ class Confirm extends Action
     public function __construct(
         Context $context,
         AddressRepositoryInterface $addressRepository,
-        SearchCriteriaInterface $searchCriteria,
         OrderService $orderService,
         OrderSender $orderSender,
         ConfigRepository $configRepository
     ) {
         $this->addressRepository = $addressRepository;
-        $this->searchCriteria = $searchCriteria;
         $this->orderService = $orderService;
         $this->orderSender = $orderSender;
         $this->configRepository = $configRepository;
@@ -79,9 +71,21 @@ class Confirm extends Action
                 }
                 $this->orderSender->send($order);
                 try {
-                    $this->saveAddress($order, $twoOrder);
+                    $this->updateCustomerAddress($order, $twoOrder);
+                } catch (LocalizedException $exception) {
+                    $message = __(
+                        "Failed to update %1 customer address: %2",
+                        $this->configRepository::PROVIDER,
+                        $exception->getMessage()
+                    );
+                    $this->orderService->addOrderComment($order, $message);
                 } catch (Exception $exception) {
-                    $this->orderService->addOrderComment($order, $exception->getMessage());
+                    $message = __(
+                        "Failed to update %1 customer address: %2",
+                        $this->configRepository::PROVIDER,
+                        $exception->getMessage()
+                    );
+                    $this->orderService->addOrderComment($order, $message);
                 }
                 $this->orderService->processOrder($order, $twoOrder['id']);
                 return $this->getResponse()->setRedirect($this->_url->getUrl('checkout/onepage/success'));
@@ -109,77 +113,36 @@ class Confirm extends Action
     }
 
     /**
-     * Save address
+     * Update customer address
      *
      * @param $order
      * @param array $twoOrder
      *
-     * @throws Exception
-     */
-    private function saveAddress($order, $twoOrder)
-    {
-        if ($order->getCustomerId()) {
-            if ($order->getBillingAddress()->getCustomerAddressId()) {
-                $customerAddress = $this->addressRepository->getById(
-                    $order->getBillingAddress()->getCustomerAddressId()
-                );
-            } else {
-                $this->searchCriteria
-                    ->setField('parent_id')
-                    ->setValue($order->getCustomerId())
-                    ->setConditionType('eq');
-                $customerAddressCollection = $this->addressRepository
-                    ->getList($this->searchCriteria)
-                    ->getItems();
-                $customerAddress = $customerAddressCollection[0] ?? null;
-            }
-            if ($customerAddress && $customerAddress->getId()) {
-                $this->copyMetadataToAddress(
-                    $twoOrder,
-                    $customerAddress
-                );
-                $this->addressRepository->save($customerAddress);
-            }
-        } else {
-            // Save metadata to shipping address
-            $shippingAddress = $order->getShippingAddress();
-            $this->copyMetadataToAddress(
-                $twoOrder,
-                $shippingAddress
-            );
-            $shippingAddress->save();
-            // Save metadata to billing address
-            $billingAddress = $order->getBillingAddress();
-            $this->copyMetadataToAddress(
-                $twoOrder,
-                $billingAddress
-            );
-            $billingAddress->save();
-        }
-    }
-
-    /**
-     * Set metadata to customer address
-     *
-     * @param array $twoOrder
-     * @param $address
-     *
      * @return void
      * @throws Exception
      */
-    private function copyMetadataToAddress(array $twoOrder, $address)
+    private function updateCustomerAddress($order, $twoOrder)
     {
-        if (isset($twoOrder['buyer']['company']['organization_number'])) {
-            $address->setData('company_id', $twoOrder['buyer']['company']['organization_number']);
-        }
-        if (isset($twoOrder['buyer']['company']['company_name'])) {
-            $address->setData('company_name', $twoOrder['buyer']['company']['company_name']);
-        }
-        if (isset($twoOrder['buyer_department'])) {
-            $address->setData('department', $twoOrder['buyer_department']);
-        }
-        if (isset($twoOrder['buyer_project'])) {
-            $address->setData('project', $twoOrder['buyer_project']);
+        $customerAddress = null;
+        if ($order->getBillingAddress()->getCustomerAddressId()) {
+            $customerAddress = $this->addressRepository->getById(
+                $order->getBillingAddress()->getCustomerAddressId()
+            );
+            if ($customerAddress && $customerAddress->getId()) {
+                if (isset($twoOrder['buyer']['company']['organization_number'])) {
+                    $customerAddress->setData('company_id', $twoOrder['buyer']['company']['organization_number']);
+                }
+                if (isset($twoOrder['buyer']['company']['company_name'])) {
+                    $customerAddress->setData('company_name', $twoOrder['buyer']['company']['company_name']);
+                }
+                if (isset($twoOrder['buyer_department'])) {
+                    $customerAddress->setData('department', $twoOrder['buyer_department']);
+                }
+                if (isset($twoOrder['buyer_project'])) {
+                    $customerAddress->setData('project', $twoOrder['buyer_project']);
+                }
+                $this->addressRepository->save($customerAddress);
+            }
         }
     }
 }

--- a/Controller/Payment/Confirm.php
+++ b/Controller/Payment/Confirm.php
@@ -62,6 +62,7 @@ class Confirm extends Action
      */
     public function execute()
     {
+        $order = null;
         try {
             $order = $this->orderService->getOrderByReference();
             $twoOrder = $this->orderService->getTwoOrderFromApi($order);
@@ -103,10 +104,9 @@ class Confirm extends Action
             }
         } catch (Exception $exception) {
             $this->orderService->restoreQuote();
-            if (isset($order)) {
+            if ($order !== null) {
                 $this->orderService->failOrder($order, $exception->getMessage());
             }
-
             $this->messageManager->addErrorMessage($exception->getMessage());
             return $this->getResponse()->setRedirect($this->_url->getUrl('checkout/cart'));
         }

--- a/Controller/Payment/Verificationfailed.php
+++ b/Controller/Payment/Verificationfailed.php
@@ -50,6 +50,7 @@ class Verificationfailed extends Action
      */
     public function execute()
     {
+        $order = null;
         try {
             $order = $this->orderService->getOrderByReference();
             $message = __(
@@ -59,10 +60,9 @@ class Verificationfailed extends Action
             throw new LocalizedException($message);
         } catch (Exception $exception) {
             $this->orderService->restoreQuote();
-            if (isset($order)) {
+            if ($order !== null) {
                 $this->orderService->failOrder($order, $exception->getMessage());
             }
-
             $this->messageManager->addErrorMessage($exception->getMessage());
             return $this->getResponse()->setRedirect($this->_url->getUrl('checkout/cart'));
         }

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -48,6 +48,7 @@ Download,Download
 "Enter details manually","Enter details manually"
 Environment,Environment
 "Failed to refund order with %1. Reason: %2","Failed to refund order with %1. Reason: %2"
+"Failed to update %1 customer address: %2","Failed to update %1 customer address: %2"
 "Find out more","Find out more"
 "First Name is not valid.","First Name is not valid."
 "Fulfilment order status","Fulfilment order status"

--- a/i18n/nb_NO.csv
+++ b/i18n/nb_NO.csv
@@ -48,6 +48,7 @@ Download,"Last ned"
 "Enter details manually","Skriv inn detaljer manuelt"
 Environment,Miljø
 "Failed to refund order with %1. Reason: %2","Kunne ikke refundere bestillingen med %1. Årsak: %2"
+"Failed to update %1 customer address: %2","Kunne ikke oppdatere %1 kundeadresse: %2"
 "Find out more","Finn ut mer"
 "First Name is not valid.","Fornavn er ikke gyldig."
 "Fulfilment order status","Oppfyllelse av ordrestatus"

--- a/i18n/nl_NL.csv
+++ b/i18n/nl_NL.csv
@@ -48,6 +48,7 @@ Download,Download
 "Enter details manually","Gegevens handmatig invoeren"
 Environment,Omgeving
 "Failed to refund order with %1. Reason: %2","Het is niet gelukt om de bestelling met %1 terug te betalen. Reden: %2"
+"Failed to update %1 customer address: %2","Kon het adres van klant %1 niet bijwerken: %2"
 "Find out more","Meer informatie"
 "First Name is not valid.","Voornaam is niet geldig."
 "Fulfilment order status","Status van vervulling bestelling"

--- a/i18n/sv_SE.csv
+++ b/i18n/sv_SE.csv
@@ -48,6 +48,7 @@ Download,"Ladda ner"
 "Enter details manually","Ange detaljer manuellt"
 Environment,Miljö
 "Failed to refund order with %1. Reason: %2","Det gick inte att återbetala beställningen med %1. Orsak: %2"
+"Failed to update %1 customer address: %2","Misslyckades med att uppdatera %1 kundadress: %2"
 "Find out more","Ta reda på mer"
 "First Name is not valid.","Förnamn är inte giltigt."
 "Fulfilment order status","Uppfyllande orderstatus"


### PR DESCRIPTION
When a customer is logged in, the address fails to save which is currently causing issues for some of our merchants.

```
Error: Call to undefined method Magento\Customer\Model\Data\Address::save() in /bitnami/magento/app/code/Two/Gateway/Controller/Payment/Confirm.php:162
Stack trace:
```

![Screenshot 2024-12-05 at 09.16.42.png](https://uploads.linear.app/dec93f74-b00f-44c6-a396-24c81f5fe6fd/42d4061f-0b22-4665-8b6e-406e14000b28/73b1181a-a299-47d5-90a3-1699ccf91074)